### PR TITLE
Adjust training config to use binary volume signal

### DIFF
--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -70,7 +70,7 @@ algo:
     fixed_type: MARKET
     long_only: true            # <-- ВКЛЮЧАЕМ лонг-онли из конфига
   action_wrapper:
-    bins_vol: 21
+    bins_vol: 2            # Используем двоичный сигнал объёма
 
 quantizer:
   filters_path: "data/binance_filters.json"


### PR DESCRIPTION
## Summary
- set the training configuration's `algo.action_wrapper.bins_vol` to 2 so the volume action becomes a binary signal

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e38593aefc832fbb756deddbbe4337