### PR TITLE
Increase CQL beta risk coefficient

### DIFF
--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -53,7 +53,7 @@ model:
   algo: "ppo"
   params:
     cql_alpha: 0.0
-    cql_beta: 1.0
+    cql_beta: 5.0
     cvar_alpha: 0.0
     cvar_weight: 0.0
     use_torch_compile: false


### PR DESCRIPTION
## Summary
- raise the `cql_beta` parameter in the training config to 5.0 while leaving other risk terms untouched

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e386a9f514832f91cb17c56232126e