### PR TITLE
Respect config hyperparameter overrides in training pipeline

### DIFF
--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -52,6 +52,15 @@ data:
 model:
   algo: "ppo"
   params:
+    learning_rate: 3.0e-4
+    gamma: 0.99
+    gae_lambda: 0.95
+    clip_range: 0.15
+    ent_coef: 0.001
+    vf_coef: 0.5
+    max_grad_norm: 0.5
+    n_steps: 1024
+    batch_size: 256
     cql_alpha: 0.0
     cql_beta: 5.0
     cvar_alpha: 0.0

--- a/test_train_model_cli.py
+++ b/test_train_model_cli.py
@@ -1,6 +1,7 @@
 import sys
 import types
 
+import pandas as pd
 import pytest
 
 
@@ -30,10 +31,38 @@ def _install_sb3_stub():
     sys.modules["sb3_contrib.common.recurrent.policies"] = policies
     recurrent.policies = policies  # type: ignore[attr-defined]
 
+    type_aliases = types.ModuleType("sb3_contrib.common.recurrent.type_aliases")
+    type_aliases.RNNStates = object  # pragma: no cover - placeholder type
+    sys.modules["sb3_contrib.common.recurrent.type_aliases"] = type_aliases
+    recurrent.type_aliases = type_aliases  # type: ignore[attr-defined]
+
 
 _install_sb3_stub()
 
 import train_model_multi_patch as train_script  # noqa: E402  (import after stub)
+
+
+class _DummyTrial:
+    def __init__(self):
+        self.suggested: list[str] = []
+        self.number = 0
+
+    def suggest_float(self, name, *_args, **_kwargs):
+        self.suggested.append(name)
+        # return mid value when bounds provided
+        if _args:
+            low = _args[0]
+            high = _args[1] if len(_args) > 1 else low
+            return (low + high) / 2 if high is not None else low
+        return 0.0
+
+    def suggest_categorical(self, name, choices, **_kwargs):
+        self.suggested.append(name)
+        return choices[0]
+
+    def suggest_int(self, name, low, high=None, **_kwargs):
+        self.suggested.append(name)
+        return low if high is None else low
 
 
 def test_dataset_split_none_skips_offline_bundle(monkeypatch: pytest.MonkeyPatch, tmp_path):
@@ -70,3 +99,68 @@ def test_dataset_split_none_skips_offline_bundle(monkeypatch: pytest.MonkeyPatch
         train_script.main()
 
     assert called is False
+
+
+def test_config_params_override_optuna(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    cfg = types.SimpleNamespace(
+        model=types.SimpleNamespace(
+            params={
+                "learning_rate": 3.0e-4,
+                "gamma": 0.99,
+                "gae_lambda": 0.95,
+                "clip_range": 0.15,
+                "ent_coef": 0.001,
+                "vf_coef": 0.5,
+                "max_grad_norm": 0.5,
+                "n_steps": 1024,
+                "batch_size": 256,
+            }
+        ),
+        algo=types.SimpleNamespace(
+            actions={},
+            action_wrapper=types.SimpleNamespace(bins_vol=2),
+        ),
+    )
+
+    trial = _DummyTrial()
+
+    class _StopWatchdogVecEnv:
+        def __init__(self, *_args, **_kwargs):
+            raise RuntimeError("stop after params")
+
+    monkeypatch.setattr(train_script, "WatchdogVecEnv", _StopWatchdogVecEnv)
+
+    df = pd.DataFrame({"price": [1.0], "ts_ms": [0]})
+
+    with pytest.raises(RuntimeError, match="stop after params"):
+        train_script.objective(
+            trial,
+            cfg,
+            total_timesteps=1024,
+            train_data_by_token={"BTCUSDT": df},
+            train_obs_by_token={},
+            val_data_by_token={"BTCUSDT": df},
+            val_obs_by_token={},
+            test_data_by_token={},
+            test_obs_by_token={},
+            norm_stats={},
+            sim_config={},
+            timing_env_kwargs={},
+            leak_guard_kwargs={},
+            trials_dir=tmp_path,
+            tensorboard_log_dir=None,
+        )
+
+    overridden_keys = {
+        "learning_rate",
+        "gamma",
+        "gae_lambda",
+        "clip_range",
+        "ent_coef",
+        "vf_coef",
+        "max_grad_norm",
+        "n_steps",
+        "batch_size",
+    }
+
+    assert overridden_keys.isdisjoint(trial.suggested)

--- a/train_model_multi_patch.py
+++ b/train_model_multi_patch.py
@@ -875,22 +875,44 @@ def objective(trial: optuna.Trial,
                 f"Invalid value '{value}' for '{key}' (expected float-compatible) in cfg.model.params"
             )
 
+    learning_rate_cfg = _coerce_optional_float(
+        _get_model_param_value(cfg, "learning_rate"), "learning_rate"
+    )
+    gamma_cfg = _coerce_optional_float(_get_model_param_value(cfg, "gamma"), "gamma")
+    gae_lambda_cfg = _coerce_optional_float(
+        _get_model_param_value(cfg, "gae_lambda"), "gae_lambda"
+    )
+    clip_range_cfg = _coerce_optional_float(
+        _get_model_param_value(cfg, "clip_range"), "clip_range"
+    )
+    ent_coef_cfg = _coerce_optional_float(
+        _get_model_param_value(cfg, "ent_coef"), "ent_coef"
+    )
+    vf_coef_cfg = _coerce_optional_float(_get_model_param_value(cfg, "vf_coef"), "vf_coef")
+    max_grad_norm_cfg = _coerce_optional_float(
+        _get_model_param_value(cfg, "max_grad_norm"), "max_grad_norm"
+    )
+    n_steps_cfg = _coerce_optional_int(_get_model_param_value(cfg, "n_steps"), "n_steps")
+    batch_size_cfg = _coerce_optional_int(
+        _get_model_param_value(cfg, "batch_size"), "batch_size"
+    )
+
     params = {
         "window_size": trial.suggest_categorical("window_size", [10, 20, 30]),
         "trade_frequency_penalty": trial.suggest_float("trade_frequency_penalty", 1e-5, 5e-4, log=True),
         "turnover_penalty_coef": trial.suggest_float("turnover_penalty_coef", 0.0, 5e-4),
-        "n_steps": trial.suggest_categorical("n_steps", [512, 1024, 2048]),
+        "n_steps": n_steps_cfg if n_steps_cfg is not None else trial.suggest_categorical("n_steps", [512, 1024, 2048]),
         "n_epochs": trial.suggest_int("n_epochs", 1, 5),
-        "batch_size": trial.suggest_categorical("batch_size", [64, 128, 256]),
-        "ent_coef": trial.suggest_float("ent_coef", 5e-5, 5e-3, log=True),
-        "learning_rate": trial.suggest_float("learning_rate", 1e-4, 5e-4, log=True),
+        "batch_size": batch_size_cfg if batch_size_cfg is not None else trial.suggest_categorical("batch_size", [64, 128, 256]),
+        "ent_coef": ent_coef_cfg if ent_coef_cfg is not None else trial.suggest_float("ent_coef", 5e-5, 5e-3, log=True),
+        "learning_rate": learning_rate_cfg if learning_rate_cfg is not None else trial.suggest_float("learning_rate", 1e-4, 5e-4, log=True),
         "risk_aversion_drawdown": trial.suggest_float("risk_aversion_drawdown", 0.05, 0.3),
         "risk_aversion_variance": trial.suggest_float("risk_aversion_variance", 0.005, 0.01),
         "weight_decay": trial.suggest_float("weight_decay", 1e-6, 1e-2, log=True),
-        "gamma": trial.suggest_float("gamma", 0.97, 0.995),
-        "gae_lambda": trial.suggest_float("gae_lambda", 0.8, 1.0),
-        "clip_range": trial.suggest_float("clip_range", 0.12, 0.18),
-        "max_grad_norm": trial.suggest_float("max_grad_norm", 0.3, 1.0),
+        "gamma": gamma_cfg if gamma_cfg is not None else trial.suggest_float("gamma", 0.97, 0.995),
+        "gae_lambda": gae_lambda_cfg if gae_lambda_cfg is not None else trial.suggest_float("gae_lambda", 0.8, 1.0),
+        "clip_range": clip_range_cfg if clip_range_cfg is not None else trial.suggest_float("clip_range", 0.12, 0.18),
+        "max_grad_norm": max_grad_norm_cfg if max_grad_norm_cfg is not None else trial.suggest_float("max_grad_norm", 0.3, 1.0),
         "hidden_dim": trial.suggest_categorical("hidden_dim", [64, 128, 256]),
         "atr_multiplier": trial.suggest_float("atr_multiplier", 1.5, 3.0),
         "trailing_atr_mult": trial.suggest_float("trailing_atr_mult", 1.0, 2.0),
@@ -898,7 +920,7 @@ def objective(trial: optuna.Trial,
         "momentum_factor": trial.suggest_float("momentum_factor", 0.1, 0.7),
         "mean_reversion_factor": trial.suggest_float("mean_reversion_factor", 0.2, 0.8),
         "adversarial_factor": trial.suggest_float("adversarial_factor", 0.3, 0.9),
-        "vf_coef": trial.suggest_float("vf_coef", 0.05, 0.5, log=True), # <-- ДОБАВЛЕНО
+        "vf_coef": vf_coef_cfg if vf_coef_cfg is not None else trial.suggest_float("vf_coef", 0.05, 0.5, log=True), # <-- ДОБАВЛЕНО
         "v_range_ema_alpha": trial.suggest_float("v_range_ema_alpha", 0.005, 0.05, log=True),
     }
 


### PR DESCRIPTION
## Summary
- allow config-provided PPO hyperparameters to bypass Optuna suggestions in `train_model_multi_patch`
- set recommended PPO defaults under `model.params` in `config_train.yaml`
- add a regression test ensuring Optuna skips suggestions when overrides exist

## Testing
- PYTHONPATH=. pytest test_train_model_cli.py::test_config_params_override_optuna -q


------
https://chatgpt.com/codex/tasks/task_e_68e38c83c0d8832fbd61405e3154e9a3