### PR TITLE
Update CVaR alpha in training configuration

### DIFF
--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -65,7 +65,7 @@ model:
     turnover_penalty_coef: 0.0
     cql_alpha: 0.0
     cql_beta: 5.0
-    cvar_alpha: 0.0
+    cvar_alpha: 0.05
     cvar_weight: 0.0
     use_torch_compile: false
 


### PR DESCRIPTION
## Summary
- update the CVaR alpha parameter in the training configuration to 0.05
- verified no other configuration files retain the previous cvar_alpha value

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3b6380aa0832fbe5bc1f4b684d3a9