### PR TITLE
Add BC weight decay schedule for DistributionalPPO

### DIFF
--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -63,11 +63,14 @@ model:
     batch_size: 256
     trade_frequency_penalty: 0.0
     turnover_penalty_coef: 0.0
-    cql_alpha: 0.0
+    cql_alpha: 1.0
     cql_beta: 5.0
     cvar_alpha: 0.05
     cvar_weight: 0.0
     use_torch_compile: false
+    bc_warmup_steps: 200000
+    bc_decay_steps: 800000
+    bc_final_coef: 0.05
 
     # Параметры головы ценности:
     num_atoms: 21   # можно 1 (обычная ценность), 11 — компромисс; >51 обычно не нужно

--- a/train_model_multi_patch.py
+++ b/train_model_multi_patch.py
@@ -909,6 +909,15 @@ def objective(trial: optuna.Trial,
     v_range_ema_alpha_cfg = _coerce_optional_float(
         _get_model_param_value(cfg, "v_range_ema_alpha"), "v_range_ema_alpha"
     )
+    bc_warmup_steps_cfg = _coerce_optional_int(
+        _get_model_param_value(cfg, "bc_warmup_steps"), "bc_warmup_steps"
+    )
+    bc_decay_steps_cfg = _coerce_optional_int(
+        _get_model_param_value(cfg, "bc_decay_steps"), "bc_decay_steps"
+    )
+    bc_final_coef_cfg = _coerce_optional_float(
+        _get_model_param_value(cfg, "bc_final_coef"), "bc_final_coef"
+    )
 
     params = {
         "window_size": trial.suggest_categorical("window_size", [10, 20, 30]),
@@ -933,6 +942,9 @@ def objective(trial: optuna.Trial,
         "adversarial_factor": trial.suggest_float("adversarial_factor", 0.3, 0.9),
         "vf_coef": vf_coef_cfg if vf_coef_cfg is not None else trial.suggest_float("vf_coef", 0.05, 0.5, log=True), # <-- ДОБАВЛЕНО
         "v_range_ema_alpha": v_range_ema_alpha_cfg if v_range_ema_alpha_cfg is not None else trial.suggest_float("v_range_ema_alpha", 0.005, 0.05, log=True),
+        "bc_warmup_steps": bc_warmup_steps_cfg if bc_warmup_steps_cfg is not None else 0,
+        "bc_decay_steps": bc_decay_steps_cfg if bc_decay_steps_cfg is not None else 0,
+        "bc_final_coef": bc_final_coef_cfg if bc_final_coef_cfg is not None else 0.0,
     }
 
     if trade_frequency_penalty_cfg is not None:
@@ -1253,6 +1265,9 @@ def objective(trial: optuna.Trial,
         cvar_alpha=params["cvar_alpha"],
         vf_coef=params["vf_coef"],
         cvar_weight=params["cvar_weight"],
+        bc_warmup_steps=params["bc_warmup_steps"],
+        bc_decay_steps=params["bc_decay_steps"],
+        bc_final_coef=params["bc_final_coef"],
         
         learning_rate=params["learning_rate"],
         n_steps=params["n_steps"],


### PR DESCRIPTION
## Summary
- add configurable warmup and decay parameters for the BC component in `DistributionalPPO`
- surface the new schedule hyperparameters through the training driver and default config
- default the config to start with a BC weight of 1.0 and linearly decay it close to zero
- log the weighted BC loss contribution and its ratio versus the PPO term for easier dominance checks

## Testing
- python -m compileall distributional_ppo.py


------
https://chatgpt.com/codex/tasks/task_e_68e3ebb099f0832fb43f57e1e11da618