### PR TITLE
Adjust LR scaling guard and align BC config defaults

### DIFF
--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -73,7 +73,7 @@ model:
     kl_lr_scale_min: 0.05
     trade_frequency_penalty: 0.0
     turnover_penalty_coef: 0.0
-    cql_alpha: 1.0
+    cql_alpha: 0.0
     cql_beta: 5.0
     cvar_alpha: 0.05
     cvar_weight: 0.0
@@ -81,7 +81,7 @@ model:
     use_torch_compile: false
     bc_warmup_steps: 200000
     bc_decay_steps: 800000
-    bc_final_coef: 0.05
+    bc_final_coef: 0.0
 
     # Параметры головы ценности:
     num_atoms: 21   # можно 1 (обычная ценность), 11 — компромисс; >51 обычно не нужно

--- a/train_model_multi_patch.py
+++ b/train_model_multi_patch.py
@@ -1263,7 +1263,8 @@ def objective(trial: optuna.Trial,
     # Рассчитываем, сколько раз будет собран полный буфер данных (rollout)
     # --- Stabilise KL behaviour and optimiser updates -----------------------
     params["target_kl"] = 0.5
-    params["learning_rate"] = float(params["learning_rate"]) * 0.1
+    if float(params["learning_rate"]) >= 1e-4:
+        params["learning_rate"] = float(params["learning_rate"]) * 0.1
     params["clip_range"] = 0.075
     params["n_epochs"] = 1
 


### PR DESCRIPTION
## Summary
- guard the additional learning-rate downscale so modern configs at 1e-5 keep their value
- align training config defaults with disabled BC/CQL settings to avoid accidental reactivation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e503f5799c832f8008190450798139