### PR TITLE
Tighten PPO clipping and gradient thresholds

### DIFF
--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -55,7 +55,7 @@ model:
     learning_rate: 1.0e-5
     gamma: 0.99
     gae_lambda: 0.95
-    clip_range: 0.05
+    clip_range: 0.03
     ent_coef: 0.001
     ent_coef_final: 0.001
     ent_coef_decay_steps: 0
@@ -63,7 +63,7 @@ model:
     ent_coef_plateau_tolerance: 0.0
     ent_coef_plateau_min_updates: 0
     vf_coef: 0.5
-    max_grad_norm: 0.5
+    max_grad_norm: 0.3
     n_steps: 1024
     n_epochs: 1
     batch_size: 512

--- a/distributional_ppo.py
+++ b/distributional_ppo.py
@@ -747,11 +747,11 @@ class DistributionalPPO(RecurrentPPO):
                 self.policy.optimizer.zero_grad(set_to_none=True)
                 loss.backward()
                 max_grad_norm = (
-                    0.5 if self.max_grad_norm is None else float(self.max_grad_norm)
+                    0.3 if self.max_grad_norm is None else float(self.max_grad_norm)
                 )
                 if max_grad_norm <= 0.0:
                     self.logger.record("warn/max_grad_norm_nonpos", float(max_grad_norm))
-                    max_grad_norm = 0.5
+                    max_grad_norm = 0.3
                 total_grad_norm = torch.nn.utils.clip_grad_norm_(
                     self.policy.parameters(), max_grad_norm
                 )

--- a/test_train_model_cli.py
+++ b/test_train_model_cli.py
@@ -111,7 +111,7 @@ def test_config_params_override_optuna(monkeypatch: pytest.MonkeyPatch, tmp_path
                 "clip_range": 0.15,
                 "ent_coef": 0.001,
                 "vf_coef": 0.5,
-                "max_grad_norm": 0.5,
+                "max_grad_norm": 0.3,
                 "n_steps": 1024,
                 "batch_size": 256,
             }
@@ -176,7 +176,7 @@ def test_invalid_batch_size_config_raises(monkeypatch: pytest.MonkeyPatch, tmp_p
                 "clip_range": 0.15,
                 "ent_coef": 0.001,
                 "vf_coef": 0.5,
-                "max_grad_norm": 0.5,
+                "max_grad_norm": 0.3,
                 "n_steps": 1024,
                 "batch_size": 257,
             }
@@ -227,7 +227,7 @@ def test_scheduler_disabled_uses_constant_lr(monkeypatch: pytest.MonkeyPatch, tm
                 "clip_range": 0.15,
                 "ent_coef": 0.001,
                 "vf_coef": 0.5,
-                "max_grad_norm": 0.5,
+                "max_grad_norm": 0.3,
                 "n_steps": 32,
                 "batch_size": 16,
                 "n_epochs": 1,

--- a/train_model_multi_patch.py
+++ b/train_model_multi_patch.py
@@ -1265,7 +1265,7 @@ def objective(trial: optuna.Trial,
     params["target_kl"] = 0.5
     if float(params["learning_rate"]) >= 1e-4:
         params["learning_rate"] = float(params["learning_rate"]) * 0.1
-    params["clip_range"] = 0.05
+    params["clip_range"] = 0.03
     params["n_epochs"] = 1
 
     kl_lr_decay_value = params.get("kl_lr_decay", 0.5)


### PR DESCRIPTION
## Summary
- lower the PPO clip range default to 0.03 and keep configuration aligned
- tighten gradient clipping defaults to 0.3 for training and supporting tests
- ensure training script uses the new policy clip range override

## Testing
- pytest test_train_model_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e513564ae0832f819832f16ab8a940