### PR TITLE
Fix NameError in distributional PPO training loop

### DIFF
--- a/distributional_ppo.py
+++ b/distributional_ppo.py
@@ -628,7 +628,7 @@ class DistributionalPPO(RecurrentPPO):
         current_update = self._update_calls
         self._update_ent_coef(current_update)
 
-        scaled_returns_tensor = torch.as_tensor(
+        returns_tensor = torch.as_tensor(
             self.rollout_buffer.returns, device=self.device, dtype=torch.float32
         ).flatten()
         scaled_returns_tensor = returns_tensor * self.value_target_scale


### PR DESCRIPTION
## Summary
- ensure the rollout returns tensor is captured before scaling in `DistributionalPPO.train`
- fix NameError during training when computing scaled returns

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e53f666b44832fb8d2e67be63f4ad8