### PR TITLE
Increase action volume bins in training config

### DIFF
--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -102,7 +102,7 @@ algo:
     fixed_type: MARKET
     long_only: true            # <-- ВКЛЮЧАЕМ лонг-онли из конфига
   action_wrapper:
-    bins_vol: 2            # Используем двоичный сигнал объёма
+    bins_vol: 6            # более «тонкие» объёмы → не вечный HOLD и не «all-in»
 
 quantizer:
   filters_path: "data/binance_filters.json"


### PR DESCRIPTION
## Summary
- increase the action wrapper volume bin count in `configs/config_train.yaml` to 6 to allow finer position sizing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e63a2b61a0832fb9fecaee9289a560